### PR TITLE
docs: исправлен некорректный URL для метода получения профиля

### DIFF
--- a/docs/integration/cdp/profile/get.md
+++ b/docs/integration/cdp/profile/get.md
@@ -6,7 +6,7 @@
 2. Ограниченный профиль с нечувствительными данными из SDK без передачи секретного ключа. Это может потребоваться для проверки некоторых свойств, чтобы кастомизировать интерфейс сайта или мобильного приложения под посетителя.
 
 ```
-GET https://api.rees46.ru/profile/get
+GET https://api.rees46.ru/profile
 ```
 
 ## Параметры
@@ -33,7 +33,7 @@ GET https://api.rees46.ru/profile/get
 ::: code-group
 
 ```shell [S2S]
-curl https://api.rees46.ru/profile/get?shop_id=...&shop_secret=...&email=...
+curl https://api.rees46.ru/profile?shop_id=...&shop_secret=...&email=...
 ```
 
 ```javascript [JS SDK]


### PR DESCRIPTION
## Проблема
В документации https://rees46.ru/help/integration/cdp/profile/get.html указан некорректный URL. 


## Исправление
URL заменен на корректный API-эндпоинт:
GET https://api.rees46.ru/profile

## Примечание
Предыдущая ссылка ведет на несуществующую страницу.